### PR TITLE
Fix typos in search errors

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -73,9 +73,9 @@
   function onSearchComplete(event) {
     results = JSON.parse(this.responseText)
     if (results.Error != null) {
-      alert("Search Error: " + resutls.Error)
+      alert("Search Error: " + results.Error)
     } else if (results.Hits.length == 0) {
-      alert("No resuts")
+      alert("No results")
     } else {
       //TODO: show results with options to click
       //alert("Search Complete: " + results.Hits.length)


### PR DESCRIPTION
Presumably, if a search error occurs, no valid error message is currently supplied. Also, when there are no results, the message is spelled incorrectly.